### PR TITLE
added github action to generate resume in PDF format

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -1,0 +1,32 @@
+name: Converting To PDF
+
+on:
+  push:
+    branches: 
+      - generatePDF
+
+jobs:
+  convert:
+    name: Convert portfolio to pdf
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Update
+      run: sudo apt-get update
+    - name: Install
+      run: sudo apt-get install xvfb wkhtmltopdf
+    - name: Convert
+      run: |
+        mkdir cv
+        portfolioURL=$(grep 'url:' _config.yml | tail -n1 | awk '{ print s $2}' | tr -d \")
+        xvfb-run wkhtmltopdf ${portfolioURL} cv/resume.pdf
+    - name: Archive convert results
+      uses: actions/upload-artifact@v2
+      with:
+        name: resume
+        path: ${{ github.workspace }}/cv


### PR DESCRIPTION
Hey @wrussell1999, we have created a github action that runs on every push to "generatePDF" branch. The action produces an artifact which can be downloaded and contains the resume in PDF format. We are using wkhtmltopdf tool for converting the website link present in _config.yml to PDF format.
We're trying to Polish it more by making the pdf savable in the repository.